### PR TITLE
Don't panic, but reject promise if invalid JSON is returned by API

### DIFF
--- a/lib/build-method.js
+++ b/lib/build-method.js
@@ -1,0 +1,73 @@
+const request = require('request')
+const { paths } = require('./config')
+
+// buildMethod returns a function that returns a promise
+const buildMethod = (endpoint, api) => query => new Promise((resolve, reject) => {
+
+  // declare path and badKey variables
+  let path = '', badKey
+
+  // check if a query object is passed in
+  if (query) {
+
+    // loop over the query object
+    for (key in query) {
+
+      // check if the key is in the paths array
+      const match = paths.includes(key)
+
+      // if this is not a valid key for the endpoint, set badKey
+      if (!endpoint.path && match || !endpoint.params.includes(key)) {
+        badKey = key
+      }
+
+      // if one of the keys matches a path, set the path for the uri
+      // then delete the key to remove from the query string
+      if (match) {
+        path += `/${query[key]}`
+        delete query[key]
+      }
+    }
+  }
+
+  // reject if a query not supported by the api is sent
+  if (badKey) {
+    return reject(`${badKey} is not a valid query to this endpoint`)
+  }
+
+  // reject if the endpoint requires a path but it is not provided
+  if (endpoint.path && !path) {
+    return reject(`'${endpoint.path}' key is required to query this endpoint`)
+  }
+
+  // Build up the uri to query
+  const uri = `${api}/${endpoint.url}${path}`
+
+  // send the request with the query string
+  request({uri, qs: query}, (err, res, body) => {
+
+    // if there is an error from the api, reject with that error
+    if (err) {
+      return reject(err)
+    }
+
+    // if there is a 404 or 400 error from the api, reject with that error
+    if (res.statusCode === 404 || res.statusCode === 400) {
+      return reject(`${res.statusCode}: ${res.statusMessage}`)
+    }
+
+    // if there is a body in the response, resolve with the body
+    if (body) {
+
+      try {
+        const data = JSON.parse(body);
+
+        return resolve(data);
+      } catch (err) {
+        return reject(Error(`invalid json in cardano API response`));
+      }
+    }
+  })
+})
+
+module.exports = buildMethod;

--- a/lib/cardano.js
+++ b/lib/cardano.js
@@ -1,71 +1,10 @@
 const request = require('request')
 const { api, endpoints, paths } = require('./config')
+const buildMethod = require('./build-method');
 
-// buildMethod returns a function that returns a promise
-const buildMethod = endpoint => query => new Promise((resolve, reject) => {
-
-  // declare path and badKey variables 
-  let path = '', badKey
-
-  // check if a query object is passed in
-  if (query) {
-
-    // loop over the query object
-    for (key in query) {
-
-      // check if the key is in the paths array
-      const match = paths.includes(key)
-
-      // if this is not a valid key for the endpoint, set badKey
-      if (!endpoint.path && match || !endpoint.params.includes(key)) {
-        badKey = key
-      }
-
-      // if one of the keys matches a path, set the path for the uri
-      // then delete the key to remove from the query string
-      if (match) {
-        path += `/${query[key]}`
-        delete query[key]
-      }
-    }
-  }
-
-  // reject if a query not supported by the api is sent
-  if (badKey) {
-    return reject(`${badKey} is not a valid query to this endpoint`)
-  }
-
-  // reject if the endpoint requires a path but it is not provided 
-  if (endpoint.path && !path) {
-    return reject(`'${endpoint.path}' key is required to query this endpoint`)
-  }
-  
-  // Build up the uri to query
-  const uri = `${api}/${endpoint.url}${path}`
-
-  // send the request with the query string 
-  request({uri, qs: query}, (err, res, body) => {
-    
-    // if there is an error from the api, reject with that error
-    if (err) {
-      return reject(err)
-    }
-
-    // if there is a 404 or 400 error from the api, reject with that error
-    if (res.statusCode === 404 || res.statusCode === 400) {
-      return reject(`${res.statusCode}: ${res.statusMessage}`)
-    }
-
-    // if there is a body in the response, resolve with the body
-    if (body) {
-      return resolve(JSON.parse(body))
-    }
-  })
-})  
-
-// reduce the endpoints array to build the methods on the cardano object 
+// reduce the endpoints array to build the methods on the cardano object
 // and then export that object
 module.exports = endpoints.reduce((obj, endpoint) => {
-  obj[endpoint.method] = buildMethod(endpoint)
+  obj[endpoint.method] = buildMethod(endpoint, api)
   return obj
 }, {})

--- a/test/test-cardano-errors.js
+++ b/test/test-cardano-errors.js
@@ -1,5 +1,7 @@
 const assert = require('assert')
 const cardano = require('../lib/cardano')
+const buildMethod = require('../lib/build-method');
+let config = require('../lib/config');
 
 describe('cardano api error tests', () => {
 
@@ -91,7 +93,7 @@ describe('cardano api error tests', () => {
       }
 
       return cardano.blocksPages(query)
-        .then(data => { 
+        .then(data => {
           console.log(data)
         })
         .catch(err => {
@@ -236,6 +238,22 @@ describe('cardano api error tests', () => {
           assert.equal('this is not a valid query to this endpoint', err)
         })
     })
-  }) 
+  })
 
+  describe('buildMethod', () => {
+    it('should not panic, but reject promise when invalid data is returned', () => {
+      return buildMethod({
+        method: 'testbadjson',
+        url: 'intl/en/about',
+        path: '',
+        params: []
+      }, 'https://www.google.com')({}).then(d => {
+        assert.fail('should have failed');
+      }).catch(err => {
+        const isCorrectError = err && err.message.indexOf('invalid json') > -1;
+
+        assert.ok(isCorrectError, 'Should have thrown invalid json error');
+      })
+    })
+  })
 })

--- a/test/test-cardano.js
+++ b/test/test-cardano.js
@@ -195,6 +195,6 @@ describe('cardano api success tests', () => {
           console.log('ERR', err)
         })
     })
-  }) 
+  })
 
 })


### PR DESCRIPTION
After running this lib in a worker for a while, I've found the cardano API sometimes returns an invalid response that causes `JSON.parse()` to panic. 

This PR handles that scenario by rejecting a promise rather than panic, allowing the thrown error to be caught. I've also added a test case for the scenario, which required moving the `buildMethod` function to its own module and allowing the base api param to be passed as an additional argument.